### PR TITLE
Create index.d.ts file to define re-exported grpc.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,1 @@
+export * as grpc from "@grpc/grpc-js";


### PR DESCRIPTION
Can we get this Typescript definition file for the main package merged in, since the static approach does recommend importing the `grpc` package from `clarifai-nodejs-grpc` itself? 

This Typescript declaration file for the main package just attaches the definitions from the `@grpc/grpc-js` package to the version of that package re-exported from this library's main entry-point. I just observed the index.js file and provided the type for what it looked like was going on. I can't guarantee that this definition is totally accurate, since I don't quite know exactly how the re-export works.