### PR TITLE
Re-export the 'grpc' import type as well

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,1 @@
+export * as grpc from '@grpc/grpc-js'


### PR DESCRIPTION
Thank you for the Typescript types and the "Static Approach!"

However, this library seems to look for `@grpc/grpc-js` in a few places and re-export the library to the consumer. The Typescript types for `grpc` are NOT exported though, leaving the consumer in a confusing position, since the other library exports in the "Static Approach" DO have Typescript types.

```js
// Without this PR
import { grpc } from "clarifai-nodejs-grpc"
// Could not find a declaration file for module 'clarifai-nodejs-grpc'. 
// 'app/node_modules/clarifai-nodejs-grpc/src/index.js' implicitly has an 'any' type.
//  Try `npm i --save-dev @types/clarifai-nodejs-grpc` if it exists or add a new 
// declaration (.d.ts) file containing `declare module 'clarifai-nodejs-grpc';`ts(7016)
```

With this `index.d.ts` file, the types from the `@grpc/grpc-js` package are forwarded on to the consumer.

```js
// With this PR
import { grpc } from "clarifai-nodejs-grpc"
// ↳ All good
```

I don't know if this is the direction that you guys are wanting to go, but I'm using this approach in my application code to get auto-complete and prevent Typescript errors.