### PR TITLE
fix: add workflow action permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Slack Notify
         if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@e21bd54eb11b06b90e2356adfc37c299da78291d # v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_ICON: "https://raw.githubusercontent.com/github/explore/2c7e603b797535e5ad8b4beb575ab3b7354666e1/topics/actions/actions.png"
           SLACK_USERNAME: "GitHub Alerts"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -23,7 +25,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Slack Notify
         if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e21bd54eb11b06b90e2356adfc37c299da78291d # v2
         env:
           SLACK_ICON: "https://raw.githubusercontent.com/github/explore/2c7e603b797535e5ad8b4beb575ab3b7354666e1/topics/actions/actions.png"
           SLACK_USERNAME: "GitHub Alerts"
@@ -37,6 +39,8 @@ jobs:
     needs: publish-npm
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - name: Create Release

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -60,7 +60,7 @@ jobs:
         python scripts/app_and_key_for_tests.py --delete-app ${CLARIFAI_APP_ID}
     - name: Slack Notify
       if: ${{ failure() }}
-      uses: rtCamp/action-slack-notify@e21bd54eb11b06b90e2356adfc37c299da78291d # v2
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
       env:
         SLACK_ICON: "https://raw.githubusercontent.com/github/explore/2c7e603b797535e5ad8b4beb575ab3b7354666e1/topics/actions/actions.png"
         SLACK_USERNAME: "GitHub Alerts"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,8 +8,9 @@ on:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -59,7 +60,7 @@ jobs:
         python scripts/app_and_key_for_tests.py --delete-app ${CLARIFAI_APP_ID}
     - name: Slack Notify
       if: ${{ failure() }}
-      uses: rtCamp/action-slack-notify@v2
+      uses: rtCamp/action-slack-notify@e21bd54eb11b06b90e2356adfc37c299da78291d # v2
       env:
         SLACK_ICON: "https://raw.githubusercontent.com/github/explore/2c7e603b797535e5ad8b4beb575ab3b7354666e1/topics/actions/actions.png"
         SLACK_USERNAME: "GitHub Alerts"


### PR DESCRIPTION
## Summary
- Added explicit `permissions` blocks to workflow jobs (`contents: read` for test/publish jobs, `contents: write` for release job)
- Pinned `rtCamp/action-slack-notify@v2` to commit SHA `e31e87e03dd19038e411e38ae27cbad084a90661` in both workflows for security